### PR TITLE
fix: missing dependency post build

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -25,6 +25,9 @@
   ],
   "author": "Vultix",
   "license": "MIT",
+  "dependencies": {
+    "tslib": "^2.4.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/casperlabs/ts-results"


### PR DESCRIPTION
Ledger Live's build fails when tslib dependency is missing and bundler cannot find it in package.json for this package. Can we please make a release with the changes on `casper-js-sdk` as well? 